### PR TITLE
Import GitHub pgp signing key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,3 +45,6 @@ USER root
 RUN /go/bin/buf completion bash > "/etc/bash_completion.d/buf"
 
 USER vscode
+
+# Import the PGP key used by GitHub for commit and PR merge signing.
+RUN curl https://github.com/web-flow.gpg | gpg --import


### PR DESCRIPTION
Import the PGP key used by GitHub for commit and PR merge signing.