### PR TITLE
Improve the documentation for aws_account attributes

### DIFF
--- a/api/schema/aws_account_resource.go
+++ b/api/schema/aws_account_resource.go
@@ -77,7 +77,7 @@ var (
 				},
 				"management_account_id": StringResourceAttributeWithMode{
 					StringAttribute: resource_schema.StringAttribute{
-						MarkdownDescription: "AWS organization management account ID. If specified, `organization_id` must also be specified.",
+						MarkdownDescription: "AWS organization management account ID. If specified, `organization_id` must also be specified. Required if `account_type` is `\"Organization\"`.",
 						Optional:            true,
 					},
 					attributeWithMode: attributeWithMode{
@@ -86,7 +86,7 @@ var (
 				},
 				"organization_id": StringResourceAttributeWithMode{
 					StringAttribute: resource_schema.StringAttribute{
-						Description: "AWS organization ID. If specified, the whole AWS organization is onboarded instead of just the AWS account. If specified, `management_account_id` must also be specified.",
+						Description: "AWS organization ID. If specified, the whole AWS organization is onboarded instead of just the AWS account. If specified, `management_account_id` must also be specified. Required if `account_type` is `\"Organization\"`.",
 						Optional:    true,
 					},
 					attributeWithMode: attributeWithMode{

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
 }
 
 provider "illumio-cloudsecure" {
-  client_id     = "my-access-id"
+  client_id     = "my-client-id"
   client_secret = "my-secret-id"
 }
 ```
@@ -45,7 +45,7 @@ Credentials can be provided by adding a `client_id` and client_secret, or an `ac
 
 ```terraform
 provider "illumio-cloudsecure" {
-  client_id     = "my-access-id"
+  client_id     = "my-client-id"
   client_secret = "my-secret-id"
 }
 ```

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -14,13 +14,16 @@ Manages an AWS account in CloudSecure.
 
 ```terraform
 resource "illumio-cloudsecure_aws_account" "example" {
-  account_id         = "123456789012"
+  account_id         = "812713887999"
   account_type       = "Organization"
-  name               = "My AWS Account"
-  service_account_id = "service-account-id"
+  name               = "Test AWS Account"
+  role_arn           = "arn:aws:iam::812713887999:role/IllumioAccess"
+  service_account_id = "eb287482-f582-4fab-8a69-88252d56eb6d"
 
   # Optional attributes
-  mode = "ReadWrite"
+  management_account_id = "965208753613"
+  mode                  = "ReadWrite"
+  organization_id       = "o-3eehyj6qk0"
 }
 ```
 
@@ -37,9 +40,9 @@ resource "illumio-cloudsecure_aws_account" "example" {
 
 ### Optional
 
-- `management_account_id` (String) AWS organization management account ID. If specified, `organization_id` must also be specified.
+- `management_account_id` (String) AWS organization management account ID. If specified, `organization_id` must also be specified. Required if `account_type` is `"Organization"`.
 - `mode` (String) Access mode.
-- `organization_id` (String) AWS organization ID. If specified, the whole AWS organization is onboarded instead of just the AWS account. If specified, `management_account_id` must also be specified.
+- `organization_id` (String) AWS organization ID. If specified, the whole AWS organization is onboarded instead of just the AWS account. If specified, `management_account_id` must also be specified. Required if `account_type` is `"Organization"`.
 
 ### Read-Only
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -9,6 +9,6 @@ terraform {
 }
 
 provider "illumio-cloudsecure" {
-  client_id     = "my-access-id"
+  client_id     = "my-client-id"
   client_secret = "my-secret-id"
 }

--- a/examples/resources/illumio-cloudsecure_aws_account/resource.tf
+++ b/examples/resources/illumio-cloudsecure_aws_account/resource.tf
@@ -1,9 +1,12 @@
 resource "illumio-cloudsecure_aws_account" "example" {
-  account_id         = "123456789012"
+  account_id         = "812713887999"
   account_type       = "Organization"
-  name               = "My AWS Account"
-  service_account_id = "service-account-id"
+  name               = "Test AWS Account"
+  role_arn           = "arn:aws:iam::812713887999:role/IllumioAccess"
+  service_account_id = "eb287482-f582-4fab-8a69-88252d56eb6d"
 
   # Optional attributes
-  mode = "ReadWrite"
+  management_account_id = "965208753613"
+  mode                  = "ReadWrite"
+  organization_id       = "o-3eehyj6qk0"
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -32,7 +32,7 @@ Credentials can be provided by adding a `client_id` and client_secret, or an `ac
 
 ```terraform
 provider "illumio-cloudsecure" {
-  client_id     = "my-access-id"
+  client_id     = "my-client-id"
   client_secret = "my-secret-id"
 }
 ```


### PR DESCRIPTION
Reword `"my-access-id"` into `"my-client-id"` in provider docs.

Document and give examples for the new attributes of the `aws_account` resource: `role_arn`, `management_account_id`, and `organization_id`.
Update the attribute values in the resource example to be more realistic.
Clarify that `management_account_id` and `organization_id` must be specified if `account_type` is `"Organization"`.