### PR TITLE
Relax the validation of illumio_region in k8s_cluster_onboarding_credential

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ cp terraform-provider-illumio-cloudsecure ~/.terraform.d/plugins/registry.terraf
       required_providers {
          illumio-cloudsecure = {
             source  = "illumio/illumio-cloudsecure"
-            version = "~> 1.0.8"
+            version = "~> 1.0.9"
          }
       }
    }

--- a/api/schema/k8s_cluster_onboarding_credential.go
+++ b/api/schema/k8s_cluster_onboarding_credential.go
@@ -4,11 +4,9 @@
 package schema
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 var (
@@ -61,13 +59,6 @@ var (
 							"Choose the Illumio Region nearest to each cluster to maximize performance and security. " +
 							"Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`.",
 						Required: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"aws-ap-southeast-2",
-								"aws-eu-west-2",
-								"aws-us-west-2",
-							),
-						},
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),
 						},

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.8"
+      version = "~> 1.0.9"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.8"
+      version = "~> 1.0.9"
     }
   }
 }


### PR DESCRIPTION
Relax the validation of the `illumio_region` attribute in the `k8s_cluster_onboarding_credential` resource to support non-prod environments.

Set version to v1.0.9.