### PR TITLE
Migrate Buf config to v2

### DIFF
--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -1,17 +1,16 @@
 # Copyright (c) Illumio, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-version: v1
+version: v2
 managed:
   enabled: true
-  go_package_prefix:
-    default: github.com/illumio/terraform-provider-illumio-cloudsecure/api
+  override:
+    - file_option: go_package_prefix
+      value: github.com/illumio/terraform-provider-illumio-cloudsecure/api
 plugins:
-  - plugin: buf.build/grpc/go:v1.5.1
+  - remote: buf.build/grpc/go:v1.5.1
     out: .
-    opt:
-      - paths=source_relative
-  - plugin: buf.build/protocolbuffers/go:v1.34.2
+    opt: paths=source_relative
+  - remote: buf.build/protocolbuffers/go:v1.34.2
     out: .
-    opt:
-      - paths=source_relative
+    opt: paths=source_relative

--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Illumio, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-version: v1
+version: v2
 lint:
   use:
     - STANDARD
@@ -9,3 +9,4 @@ lint:
     - MESSAGE_PASCAL_CASE
   rpc_allow_google_protobuf_empty_requests: true
   rpc_allow_google_protobuf_empty_responses: true
+  disallow_comment_ignores: true


### PR DESCRIPTION
Follow Buf's ["Migrate to v2 configuration files"](https://buf.build/docs/migration-guides/migrate-v2-config-files) guide to migrate `buf.*.yaml` files from v1 to v2.