### PR TITLE
Bump golangci-lint to v2.0.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ ARG VARIANT=1.24-bookworm
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
 ARG BUF_VERSION=v1.52.1
-ARG GOLANGCI_VERSION=v1.61.0
+ARG GOLANGCI_VERSION=v2.0.2
 ARG TERRAFORM_VERSION=1.11.4-1
 
 USER root
@@ -38,7 +38,7 @@ USER vscode
 RUN terraform -install-autocomplete
 
 RUN go install github.com/bufbuild/buf/cmd/buf@${BUF_VERSION} \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_VERSION}
+    && go install go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 USER root
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,7 +19,8 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repo
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,13 +19,15 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: Check out repo
         uses: actions/checkout@v4
+
       - name: Set up go
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: true
+
       - name: Lint Golang
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,32 +1,32 @@
 name: golangci-lint
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - '**.go'
-    pull_request:
-        branches:
-            - main
-        paths:
-            - '**.go'
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.go"
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    golangci:
-        name: golangci-lint
-        runs-on: ubuntu-latest
-        steps:
-            - name: Check out code
-              uses: actions/checkout@v4
-            - name: Set up go
-              uses: actions/setup-go@v5
-              with:
-                go-version-file: "go.mod"
-                cache: true
-            - name: Lint Golang
-              uses: golangci/golangci-lint-action@v6
-              with:
-                version: v1.60.3
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - name: Lint Golang
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,27 @@ jobs:
   goreleaser:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Check out repo
+        uses: actions/checkout@v4
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: true
+
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,5 +20,8 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
-      - run: semgrep ci
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: semgrep ci

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code
+      - name: Check out repo
         uses: actions/checkout@v4
+
       - name: Lint Terraform
         uses: actionshub/terraform-lint@2.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,40 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
+version: "2"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
-  enable-all: true
+  default: all
   disable:
     - cyclop
     - depguard
     - dupl
     - err113
-    - execinquery
     - exhaustruct
-    - exportloopref
     - funlen
     - gochecknoglobals
     - gochecknoinits
     - godox
-    - gofumpt
-    - gomnd
     - ireturn
     - lll
     - mnd
     - nonamedreturns
     - paralleltest
+    - revive
     - testpackage
     - varnamelen
     - wrapcheck
+  settings:
+    gosec:
+      config:
+        G302: "0644" # Allow creating file with mode 0644
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    # - gofumpt
+    - goimports
+    # - golines

--- a/api/fakeservergen/main.go
+++ b/api/fakeservergen/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/illumio/terraform-provider-illumio-cloudsecure/api/schema"
 )
@@ -27,7 +28,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	file, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filepath.Clean(outfile), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open file %q: %s", outfile, err)
 		os.Exit(1)

--- a/api/protogen/main.go
+++ b/api/protogen/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/illumio/terraform-provider-illumio-cloudsecure/api/schema"
 )
@@ -32,7 +33,7 @@ func main() {
 	// doesn't modify the tags of existing attributes.
 	var tagger *apiSpecTagger
 
-	tagsJSONBytes, err := os.ReadFile(tagsfile)
+	tagsJSONBytes, err := os.ReadFile(filepath.Clean(tagsfile))
 	if err == nil {
 		err = json.Unmarshal(tagsJSONBytes, &tagger)
 		if err != nil {
@@ -45,7 +46,7 @@ func main() {
 		tagger = newAPISpecTagger()
 	}
 
-	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filepath.Clean(outfile), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open output file %q: %s", outfile, err)
 		os.Exit(1)

--- a/api/providergen/main.go
+++ b/api/providergen/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/illumio/terraform-provider-illumio-cloudsecure/api/schema"
 )
@@ -27,7 +28,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filepath.Clean(outfile), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open file %q: %s", outfile, err)
 		os.Exit(1)

--- a/api/schema/names.go
+++ b/api/schema/names.go
@@ -4,13 +4,13 @@
 package schema
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasource_schema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -28,14 +28,14 @@ func ProtoMessageName(tfName string) string {
 
 // SortResourceAttributes returns the sorted names of a set of resource attributes.
 func SortResourceAttributes(attrs map[string]resource_schema.Attribute) []string {
-	names := maps.Keys(attrs)
+	names := slices.AppendSeq(make([]string, 0, len(attrs)), maps.Keys(attrs))
 	sortAttributeNames(names)
 
 	return names
 }
 
 func SortObjectAttributes(attrs map[string]attr.Type) []string {
-	names := maps.Keys(attrs)
+	names := slices.AppendSeq(make([]string, 0, len(attrs)), maps.Keys(attrs))
 	sortAttributeNames(names)
 
 	return names
@@ -43,7 +43,7 @@ func SortObjectAttributes(attrs map[string]attr.Type) []string {
 
 // SortDataSourceAttributes returns the sorted names of a set of data source attributes.
 func SortDataSourceAttributes(attrs map[string]datasource_schema.Attribute) []string {
-	names := maps.Keys(attrs)
+	names := slices.AppendSeq(make([]string, 0, len(attrs)), maps.Keys(attrs))
 	sortAttributeNames(names)
 
 	return names


### PR DESCRIPTION
Install golangci-lint v2.0.2 in devcontainer.
Update golangci.yml configuration to version 2.
Fix gosec G304 warnings about potentially tainted filenames.

Update all GitHub Action versions.