### PR TITLE
k8s_cluster: Improve the description of illumio_region

### DIFF
--- a/api/schema/k8s_cluster.go
+++ b/api/schema/k8s_cluster.go
@@ -44,10 +44,9 @@ var (
 				},
 				"illumio_region": StringResourceAttributeWithMode{
 					StringAttribute: resource_schema.StringAttribute{
-						MarkdownDescription: "Illumio Region where the k8s cluster will be onboarded or offboarded from" +
-							"An Illumio Region is a designated cloud region where the CloudSecure k8s operators in onboarded k8s clusters connect after onboarding. " +
-							"Choose the Illumio Region nearest to each cluster to maximize performance and security. " +
-							"Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`.",
+						MarkdownDescription: "Illumio Region where the k8s cluster will be onboarded. " +
+							"An Illumio Region is a designated cloud region where the CloudSecure cloud-operator deployed in the k8s cluster connects after onboarding. " +
+							"Choose the Illumio Region nearest to the k8s cluster to maximize performance and security. Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`.",
 						Required: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -36,7 +36,7 @@ output "example_client_secret" {
 
 ### Required
 
-- `illumio_region` (String) Illumio Region where the k8s cluster will be onboarded or offboarded fromAn Illumio Region is a designated cloud region where the CloudSecure k8s operators in onboarded k8s clusters connect after onboarding. Choose the Illumio Region nearest to each cluster to maximize performance and security. Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`.
+- `illumio_region` (String) Illumio Region where the k8s cluster will be onboarded. An Illumio Region is a designated cloud region where the CloudSecure cloud-operator deployed in the k8s cluster connects after onboarding. Choose the Illumio Region nearest to the k8s cluster to maximize performance and security. Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`.
 
 ### Optional
 


### PR DESCRIPTION
Fix the description of the illumio_region attribute to be consistent with the corresponding variable in the k8s_cluster module: https://github.com/illumio/terraform-illumio-cloudsecure/blob/15355adfc547226107f41755c9513d652bcb9f80/modules/k8s_cluster/variables.tf#L14C18-L14C477