### PR TITLE
Add ListNestedResourceAttributeWithMode for immutable nested lists

### DIFF
--- a/api/schema/attributemode.go
+++ b/api/schema/attributemode.go
@@ -156,6 +156,16 @@ type ListResourceAttributeWithMode struct {
 type ListNestedResourceAttributeWithMode struct {
 	resource_schema.ListNestedAttribute
 	attributeWithMode
+// ListNestedResourceAttributeWithMode is a ListNestedAttribute with an explicit attribute mode.
+type ListNestedResourceAttributeWithMode struct {
+	resource_schema.ListNestedAttribute
+	attributeWithMode
+}
+
+// ListResourceAttributeWithMode is a ListAttribute with an explicit attribute mode.
+type ListResourceAttributeWithMode struct {
+resource_schema.ListAttribute
+attributeWithMode
 }
 
 // MapResourceAttributeWithMode is a MapAttribute with an explicit attribute mode.
@@ -195,8 +205,8 @@ var (
 	_ AttributeWithMode = Float64ResourceAttributeWithMode{}
 	_ AttributeWithMode = Int32ResourceAttributeWithMode{}
 	_ AttributeWithMode = Int64ResourceAttributeWithMode{}
-	_ AttributeWithMode = ListResourceAttributeWithMode{}
 	_ AttributeWithMode = ListNestedResourceAttributeWithMode{}
+	_ AttributeWithMode = ListResourceAttributeWithMode{}
 	_ AttributeWithMode = MapResourceAttributeWithMode{}
 	_ AttributeWithMode = NumberResourceAttributeWithMode{}
 	_ AttributeWithMode = ObjectResourceAttributeWithMode{}

--- a/api/schema/attributemode.go
+++ b/api/schema/attributemode.go
@@ -146,26 +146,16 @@ type Int64ResourceAttributeWithMode struct {
 	attributeWithMode
 }
 
+// ListNestedResourceAttributeWithMode is a ListNestedAttribute with an explicit attribute mode.
+type ListNestedResourceAttributeWithMode struct {
+	resource_schema.ListNestedAttribute
+	attributeWithMode
+}
+
 // ListResourceAttributeWithMode is a ListAttribute with an explicit attribute mode.
 type ListResourceAttributeWithMode struct {
 	resource_schema.ListAttribute
 	attributeWithMode
-}
-
-// ListNestedResourceAttributeWithMode is a ListNestedAttribute with an explicit attribute mode.
-type ListNestedResourceAttributeWithMode struct {
-	resource_schema.ListNestedAttribute
-	attributeWithMode
-// ListNestedResourceAttributeWithMode is a ListNestedAttribute with an explicit attribute mode.
-type ListNestedResourceAttributeWithMode struct {
-	resource_schema.ListNestedAttribute
-	attributeWithMode
-}
-
-// ListResourceAttributeWithMode is a ListAttribute with an explicit attribute mode.
-type ListResourceAttributeWithMode struct {
-resource_schema.ListAttribute
-attributeWithMode
 }
 
 // MapResourceAttributeWithMode is a MapAttribute with an explicit attribute mode.

--- a/api/schema/attributemode.go
+++ b/api/schema/attributemode.go
@@ -152,6 +152,12 @@ type ListResourceAttributeWithMode struct {
 	attributeWithMode
 }
 
+// ListNestedResourceAttributeWithMode is a ListNestedAttribute with an explicit attribute mode.
+type ListNestedResourceAttributeWithMode struct {
+	resource_schema.ListNestedAttribute
+	attributeWithMode
+}
+
 // MapResourceAttributeWithMode is a MapAttribute with an explicit attribute mode.
 type MapResourceAttributeWithMode struct {
 	resource_schema.MapAttribute
@@ -190,6 +196,7 @@ var (
 	_ AttributeWithMode = Int32ResourceAttributeWithMode{}
 	_ AttributeWithMode = Int64ResourceAttributeWithMode{}
 	_ AttributeWithMode = ListResourceAttributeWithMode{}
+	_ AttributeWithMode = ListNestedResourceAttributeWithMode{}
 	_ AttributeWithMode = MapResourceAttributeWithMode{}
 	_ AttributeWithMode = NumberResourceAttributeWithMode{}
 	_ AttributeWithMode = ObjectResourceAttributeWithMode{}

--- a/api/schema/schema_test.go
+++ b/api/schema/schema_test.go
@@ -5,6 +5,8 @@ package schema
 
 import (
 	"sort"
+
+	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func (suite *SchemaTestSuite) TestResourcesAreSorted() {
@@ -67,5 +69,59 @@ func (suite *SchemaTestSuite) TestDataSourcesHaveUniqueTypeNames() {
 		suite.False(found, "Data source type name %q is duplicated at index %d", typeName, i)
 
 		typeNames[typeName] = struct{}{}
+	}
+}
+
+func (suite *SchemaTestSuite) TestGetResourceAttributeMode() {
+	tests := []struct {
+		name         string
+		attr         resource_schema.Attribute
+		expectedMode AttributeMode
+	}{
+		{
+			name: "ListNestedAttribute defaults to ReadWrite",
+			attr: resource_schema.ListNestedAttribute{
+				Required: true,
+			},
+			expectedMode: ReadWriteAttributeMode,
+		},
+		{
+			name: "ListNestedResourceAttributeWithMode returns configured mode",
+			attr: ListNestedResourceAttributeWithMode{
+				ListNestedAttribute: resource_schema.ListNestedAttribute{
+					Required: true,
+				},
+				attributeWithMode: attributeWithMode{
+					Mode: ImmutableAttributeMode,
+				},
+			},
+			expectedMode: ImmutableAttributeMode,
+		},
+		{
+			name: "StringAttribute defaults to ReadWrite",
+			attr: resource_schema.StringAttribute{
+				Required: true,
+			},
+			expectedMode: ReadWriteAttributeMode,
+		},
+		{
+			name: "StringResourceAttributeWithMode returns configured mode",
+			attr: StringResourceAttributeWithMode{
+				StringAttribute: resource_schema.StringAttribute{
+					Required: true,
+				},
+				attributeWithMode: attributeWithMode{
+					Mode: ImmutableAttributeMode,
+				},
+			},
+			expectedMode: ImmutableAttributeMode,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			mode := GetResourceAttributeMode(tc.attr)
+			suite.Equal(tc.expectedMode, mode)
+		})
 	}
 }


### PR DESCRIPTION
Add a wrapper type that allows ListNestedAttribute to have an explicit attribute mode (e.g., ImmutableAttributeMode). This enables excluding nested list fields from update requests when they should be immutable.