### PR TITLE
Set version to 2.0.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.8.2"
+      version = "~> 2.0.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.8.2"
+      version = "~> 2.0.0"
     }
   }
 }


### PR DESCRIPTION
This release removes attributes, which is a breaking change, so bumping the version's major number following the [Terraform versioning specification](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#example-major-number-increments).